### PR TITLE
fix case failing when invalid front update became valid after top was updated

### DIFF
--- a/project/backend/src/main/java/com/ufrgs/superfuturo/SuperfuturoApplication.java
+++ b/project/backend/src/main/java/com/ufrgs/superfuturo/SuperfuturoApplication.java
@@ -8,7 +8,6 @@ import com.ufrgs.superfuturo.logic.SuperFuturoLogic;
 
 @SpringBootApplication
 public class SuperfuturoApplication {
-
 	public static void main(final String[] args) {
 		SpringApplication.run(SuperfuturoApplication.class, args);
 		SuperFuturoLogic.start();

--- a/project/backend/src/main/java/com/ufrgs/superfuturo/client/FrontendClient.java
+++ b/project/backend/src/main/java/com/ufrgs/superfuturo/client/FrontendClient.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,12 +14,14 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 
 import com.google.gson.Gson;
 import com.ufrgs.superfuturo.model.Product;
 import com.ufrgs.superfuturo.model.StockProducts;
+import org.springframework.web.util.UriBuilder;
 
 
 public class FrontendClient {
@@ -32,16 +35,20 @@ public class FrontendClient {
 		
 	}
 	
-	public void sendReturnProduct(final Product product) {
+	public void sendReturnProduct(final Product product) throws URISyntaxException {
 		System.out.println("User returned product " + product.getName());
 	    
 		final HttpClient httpclient = HttpClients.createDefault();
-		final HttpPost httppost = new HttpPost(this.removeProductApiUrl);
+		final URIBuilder uriBuilder = new URIBuilder(this.removeProductApiUrl);
 		final List<NameValuePair> params = new ArrayList<NameValuePair>(1);
 		params.add(new BasicNameValuePair(this.nameParamString, product.getName()));
+		// add all needed params
+		uriBuilder.addParameters(params);
+		final HttpPost httppost = new HttpPost(uriBuilder.build());
 
 		try {
 			httppost.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
+			System.out.println(httppost.toString());
 			System.out.println(new UrlEncodedFormEntity(params, "UTF-8").toString());
 			httpclient.execute(httppost);
 		} catch (ClientProtocolException e) {
@@ -52,13 +59,16 @@ public class FrontendClient {
 	    
 	}
 	
-	public void sendBuyProduct(final Product product) {
+	public void sendBuyProduct(final Product product) throws URISyntaxException {
 		System.out.println("User bought product " + product.getName());
 		
 		final HttpClient httpclient = HttpClients.createDefault();
-		final HttpPost httppost = new HttpPost(this.addProductApiUrl);
+		final URIBuilder uriBuilder = new URIBuilder(this.addProductApiUrl);
 		final List<NameValuePair> params = new ArrayList<NameValuePair>(1);
 		params.add(new BasicNameValuePair(this.nameParamString, product.getName()));
+		// add all needed params
+		uriBuilder.addParameters(params);
+		final HttpPost httppost = new HttpPost(uriBuilder.build());
 
 		try {
 			httppost.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));

--- a/project/backend/src/main/java/com/ufrgs/superfuturo/controller/InputObjectFromFrontCameraController.java
+++ b/project/backend/src/main/java/com/ufrgs/superfuturo/controller/InputObjectFromFrontCameraController.java
@@ -20,8 +20,6 @@ public class InputObjectFromFrontCameraController {
 	
 	@PostMapping("/list")
 	public ResponseEntity<List<InputObject>> createInputObjectList(@Valid @RequestBody final List<InputObject> inputObjects) {
-		System.out.println("PRINTING A LOT OF STUFF: front: ");
-		InputObject.printListOfInputObjects(inputObjects);
 		YoloParserLogic.processFrontInputObjects(inputObjects);
 		YoloParserLogic.commitTransactions();
 
@@ -36,9 +34,6 @@ public class InputObjectFromFrontCameraController {
 	
 	@PostMapping("/startlist")
 	public ResponseEntity<List<InputObject>> createStartInputObjectList(@Valid @RequestBody final List<InputObject> inputObjects) {
-		System.out.println("PRINTING A LOT OF STUFF: front: ");
-		InputObject.printListOfInputObjects(inputObjects);
-
 		YoloParserLogic.setupFrontInputObjects(inputObjects);
 
 		final URI location = ServletUriComponentsBuilder

--- a/project/backend/src/main/java/com/ufrgs/superfuturo/model/Stock.java
+++ b/project/backend/src/main/java/com/ufrgs/superfuturo/model/Stock.java
@@ -1,5 +1,6 @@
 package com.ufrgs.superfuturo.model;
 
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,8 +64,14 @@ public class Stock {
 			
 			Stock.stockedProducts.remove(productToBuy);
 			Stock.createBuyOrder(user, product);
-			Stock.frontendClient.sendBuyProduct(product);
-			
+
+			try {
+				Stock.frontendClient.sendBuyProduct(product);
+			} catch (final URISyntaxException ex) {
+				ex.printStackTrace();
+				System.out.println("FATAL ERROR: error while building URI, request won't be transmitted to the backend");
+			}
+
 			return true;
 		}
 		
@@ -82,8 +89,14 @@ public class Stock {
 		
 		Stock.stockedProducts.add(product);
 		Stock.createReturnOrder(user, product);
-		Stock.frontendClient.sendReturnProduct(product);
-		
+
+		try {
+			Stock.frontendClient.sendReturnProduct(product);
+		} catch (final URISyntaxException ex) {
+			ex.printStackTrace();
+			System.out.println("FATAL ERROR: error while building URI, request won't be transmitted to the backend");
+		}
+
 		return true;
 	}
 	


### PR DESCRIPTION
Also minor adjustments/fixes

* created a new variable to store front updates that are deemed inconsistent, so we can eventually (through timeout) take a peek and see if it is actually consistent now, which means that it was made consistent by an update on the top view, therefore it was always a valid entry, just arrived too soon.